### PR TITLE
Fixed updating of castling rights on rook captures

### DIFF
--- a/chess/board_impl.cpp
+++ b/chess/board_impl.cpp
@@ -184,6 +184,16 @@ namespace space {
 							newBoard->m_canWhiteCastleRight = false;
 					}
 				}
+
+				// If white captures (rook or not) on h8 or a8, black loses right
+				// to castle.
+				if (move.destinationRank == 7 && move.destinationFile == 0) {
+					newBoard->m_canBlackCastleRight = false;
+				}
+				else if (move.destinationRank == 7 && move.destinationFile == 7) {
+					newBoard->m_canBlackCastleLeft = false;
+				}
+
 				space_assert(!newBoard->m_canWhiteCastleLeft || newBoard->m_pieces[0][0].pieceType == PieceType::Rook,
 					   "White Left Rook moved, cant castle");
 				space_assert(!newBoard->m_canWhiteCastleRight || newBoard->m_pieces[0][7].pieceType == PieceType::Rook,
@@ -200,6 +210,17 @@ namespace space {
 							newBoard->m_canBlackCastleRight = false;
 					}
 				}
+
+				// If white captures (rook or not) on h8 or a8, black loses right
+				// to castle.
+				if (move.destinationRank == 0 && move.destinationFile == 0) {
+					newBoard->m_canWhiteCastleLeft = false;
+				}
+				else if (move.destinationRank == 0 && move.destinationFile == 7) {
+					newBoard->m_canWhiteCastleRight = false;
+				}
+
+
 				space_assert(!newBoard->m_canBlackCastleLeft || newBoard->m_pieces[7][7].pieceType == PieceType::Rook,
 					"Black Left Rook moved, cant castle");
 				space_assert(!newBoard->m_canBlackCastleRight || newBoard->m_pieces[7][0].pieceType == PieceType::Rook,

--- a/chess_test/chess_test.cpp
+++ b/chess_test/chess_test.cpp
@@ -96,6 +96,41 @@ TEST(BoardSuite, BoardMovesTest) {
 
 }
 
+TEST(BoardSuite, CastlingFlagUpdate) {
+	using namespace space;
+
+	// Capture on h8
+	auto fen = Fen("3rk2r/1p2np2/pNp3q1/2PnQ1pp/1P6/P2P3P/4BPP1/1R3RK1 w k - 1 24");
+	auto board = BoardImpl::fromFen(fen);
+	auto Qxh8 = Move(4, 4, 7, 7);
+	auto newBoard = board->updateBoard(Qxh8);
+	ASSERT_TRUE(newBoard.has_value());
+	ASSERT_FALSE(newBoard.value()->canCastleLeft(Color::Black));
+
+	// Capture on a8
+	fen = Fen("r3k2r/8/8/3Q4/8/8/8/R3K2R w KQkq - 0 1");
+	board = BoardImpl::fromFen(fen);
+	auto Qxa8 = Move(4, 3, 7, 0);
+	newBoard = board->updateBoard(Qxa8);
+	ASSERT_TRUE(newBoard.has_value());
+	ASSERT_FALSE(newBoard.value()->canCastleRight(Color::Black));
+
+	// Capture on a1
+	fen = Fen("r3k2r/8/8/8/3q4/8/8/R3K2R b KQkq - 0 1");
+	board = BoardImpl::fromFen(fen);
+	auto Qxa1 = Move(3, 3, 0, 0);
+	newBoard = board->updateBoard(Qxa1);
+	ASSERT_TRUE(newBoard.has_value());
+	ASSERT_FALSE(newBoard.value()->canCastleLeft(Color::White));
+
+	// Capture on h1
+	fen = Fen("r3k2r/8/8/8/4q3/8/8/R3K2R b KQkq - 0 1");
+	board = BoardImpl::fromFen(fen);
+	auto Qxh1 = Move(3, 4, 0, 7);
+	newBoard = board->updateBoard(Qxh1);
+	ASSERT_TRUE(newBoard.has_value());
+	ASSERT_FALSE(newBoard.value()->canCastleRight(Color::White));
+}
 
 TEST(AlgoSuite, AlgoLinearTest) {
 	std::vector<double> wts01 = {1, 5, 4, 4, 10};


### PR DESCRIPTION
On capturing a rook on any of a1, a8, h1, h8 should lose the appropriate color the castling rights on the appropriate side. This PR fixes the previously broken behaviour.