### PR TITLE
Fixed en passant pawn checks and en passant square FEN parsing

### DIFF
--- a/chess/board.h
+++ b/chess/board.h
@@ -41,6 +41,10 @@ namespace space {
 
 		virtual bool isStaleMate() const = 0;
 		virtual bool isCheckMate() const = 0;
+		virtual bool isUnderCheck(
+			Color color,
+			std::optional<Position> targetKingPosition = std::nullopt
+		) const = 0;
 		virtual std::optional<Ptr> updateBoard(Move move) const = 0;
 		virtual MoveMap getValidMoves() const = 0;
 	};

--- a/chess/board_impl.cpp
+++ b/chess/board_impl.cpp
@@ -1,6 +1,7 @@
 #include "board_impl.h"
 #include "common/base.h"
 
+#include <iostream>
 #include <sstream>
 #include <stdexcept>
 #include <vector>
@@ -437,15 +438,21 @@ namespace space {
 		ss.get(c);
 		if (c >= 'a' && c <= 'h')
 		{
-			int rank = c - 'a';
+			int file = c - 'a';
 			ss.get(c);
-			int file;
+			int rank;
 			if (c >= '1' && c <= '8')
-				file = c - '1';
+				rank = c - '1';
 			else
 				throw std::runtime_error(std::string("Expecting a digit from 1 to 8, got '") + c + "'");
 			if (board->m_whoPlaysNext == Color::Black)
 				rank += 1;
+			else
+				rank -= 1;
+			space_assert(
+				board->m_pieces[rank][file].pieceType == PieceType::Pawn,
+				"En passant capture square does not have a pawn in front of it."
+			);
 			board->m_pieces[rank][file].pieceType = PieceType::EnPassantCapturablePawn;
 		}
 		else if (c != '-') throw std::runtime_error(std::string("Expecting 'a'-'h' or '-', got '") + c + "'");
@@ -638,7 +645,7 @@ namespace space {
 		}
 
 		// for pawns, we examine for obstruction and capture rules here
-		if (t == PieceType::Pawn)
+		if (t == PieceType::Pawn || t == PieceType::EnPassantCapturablePawn)
 		{
 			int direction = (c == Color::White ? 1 : -1);
 

--- a/chess/board_impl.cpp
+++ b/chess/board_impl.cpp
@@ -1,7 +1,6 @@
 #include "board_impl.h"
 #include "common/base.h"
 
-#include <iostream>
 #include <sstream>
 #include <stdexcept>
 #include <vector>

--- a/chess/board_impl.h
+++ b/chess/board_impl.h
@@ -18,6 +18,10 @@ namespace space {
 		bool canCastleRight(Color color) const override;
 		bool isStaleMate() const override;
 		bool isCheckMate() const override;
+		bool isUnderCheck(
+			Color color,
+			std::optional<Position> targetKingPosition = std::nullopt
+		) const override;
 		std::optional<Ptr> updateBoard(Move move) const override;
 		MoveMap getValidMoves() const override;
 
@@ -32,7 +36,6 @@ namespace space {
 		bool m_canBlackCastleRight;
 		Color m_whoPlaysNext;
 		bool checkObstructions(Move m) const;
-		bool isUnderCheck(Color color, std::optional<Position> targetKingPosition = std::nullopt) const;
 		std::vector<Move> getAllMoves(Color color) const;
 		std::vector<Move> getAllMoves(Position position) const;
 		std::vector<Move> getAllmovesWithoutObstructions(Color color) const;

--- a/chess_test/chess_test.cpp
+++ b/chess_test/chess_test.cpp
@@ -3,6 +3,7 @@
 #include <chess/board_impl.h>
 #include <chess/fen.h>
 #include <algo_linear/algoLinear.h>
+#include <algorithm>
 
 
 TEST(BoardSuite, StartingBoardTest) {
@@ -96,6 +97,27 @@ TEST(BoardSuite, BoardMovesTest) {
 
 }
 
+TEST(BoardSuite, FenEnpassantablePawnTest) {
+	using namespace space;
+
+	auto fen = Fen("2rr2k1/p5pb/7p/1p5P/KPq3P1/8/8/8 w - b6 0 38");
+	auto board = BoardImpl::fromFen(fen);
+	auto piece_on_b5 = board->getPiece(Position(4, 1));
+	ASSERT_TRUE(piece_on_b5.has_value());
+	ASSERT_EQ(piece_on_b5.value().pieceType, PieceType::EnPassantCapturablePawn);
+}
+
+TEST(BoardSuite, EnpassantablePawnCheckTest) {
+	using namespace space;
+
+	auto fen = Fen("2rr2k1/p5pb/7p/1p5P/KPq3P1/8/8/8 w - b6 0 38");
+	auto board = BoardImpl::fromFen(fen);
+	auto piece_on_b5 = board->getPiece(Position(4, 1));
+	ASSERT_TRUE(piece_on_b5.has_value());
+	ASSERT_EQ(piece_on_b5.value().pieceType, PieceType::EnPassantCapturablePawn);
+
+	ASSERT_TRUE(board->isUnderCheck(Color::White));
+}
 
 TEST(AlgoSuite, AlgoLinearTest) {
 	std::vector<double> wts01 = {1, 5, 4, 4, 10};

--- a/chess_test/chess_test.cpp
+++ b/chess_test/chess_test.cpp
@@ -3,7 +3,6 @@
 #include <chess/board_impl.h>
 #include <chess/fen.h>
 #include <algo_linear/algoLinear.h>
-#include <algorithm>
 
 
 TEST(BoardSuite, StartingBoardTest) {
@@ -105,6 +104,12 @@ TEST(BoardSuite, FenEnpassantablePawnTest) {
 	auto piece_on_b5 = board->getPiece(Position(4, 1));
 	ASSERT_TRUE(piece_on_b5.has_value());
 	ASSERT_EQ(piece_on_b5.value().pieceType, PieceType::EnPassantCapturablePawn);
+
+	fen = Fen("2rr2k1/p5pb/7p/1p5P/1Pp2qP1/K7/8/8 b - b3 0 1");
+	board = BoardImpl::fromFen(fen);
+	auto piece_on_b4 = board->getPiece(Position(3, 1));
+	ASSERT_TRUE(piece_on_b4.has_value());
+	ASSERT_EQ(piece_on_b4.value().pieceType, PieceType::EnPassantCapturablePawn);
 }
 
 TEST(BoardSuite, EnpassantablePawnCheckTest) {


### PR DESCRIPTION
This PR fixes two bugs:
1. Parsing en passant squares from FEN was broken.
2. Checks by pawns that are en passant capturable were not detected.