### PR TITLE
Added board pretty printer with terminal colors and unicode pieces

### DIFF
--- a/chess/board.h
+++ b/chess/board.h
@@ -34,7 +34,7 @@ namespace space {
 		using MoveMap = std::map<Move, Ptr>;
 		virtual Color whoPlaysNext() const = 0;
 		virtual std::optional<Piece> getPiece(Position position) const = 0;
-		
+
 		// (Left and right from that player's point of view)
 		virtual bool canCastleLeft(Color color) const = 0;
 		virtual bool canCastleRight(Color color) const = 0;
@@ -47,6 +47,11 @@ namespace space {
 		) const = 0;
 		virtual std::optional<Ptr> updateBoard(Move move) const = 0;
 		virtual MoveMap getValidMoves() const = 0;
+		virtual std::string as_string(
+				bool unicode_pieces = false,
+				bool terminal_colors = false,
+				Color perspective = Color::White
+		) const = 0;
 	};
 
 }

--- a/chess/board_impl.cpp
+++ b/chess/board_impl.cpp
@@ -37,6 +37,107 @@ namespace {
 		}
 	}
 
+	std::string piece_to_unicode(const space::Piece& piece) {
+		using namespace space;
+		if (piece.color == Color::White) {
+			switch (piece.pieceType) {
+				case PieceType::King: return "\u2654";
+				case PieceType::Queen: return "\u2655";
+				case PieceType::Rook: return "\u2656";
+				case PieceType::Bishop: return "\u2657";
+				case PieceType::Knight: return "\u2658";
+				case PieceType::Pawn: return "\u2659";
+				case PieceType::EnPassantCapturablePawn: return "\u2659";
+			}
+		}
+		else {
+			switch (piece.pieceType) {
+				case PieceType::King: return "\u265a";
+				case PieceType::Queen: return "\u265b";
+				case PieceType::Rook: return "\u265c";
+				case PieceType::Bishop: return "\u265d";
+				case PieceType::Knight: return "\u265e";
+				case PieceType::Pawn: return "\u265f";
+				case PieceType::EnPassantCapturablePawn: return "\u265f";
+			}
+		}
+
+		// PieceType::None
+		return " ";
+	}
+
+	inline char pieceTypeToChar(space::PieceType pieceType)
+	{
+		switch (pieceType)
+		{
+		case space::PieceType::Pawn:
+			return 'p';
+		case space::PieceType::EnPassantCapturablePawn:
+			return 'p';
+		case space::PieceType::Rook:
+			return 'r';
+		case space::PieceType::Knight:
+			return 'n';
+		case space::PieceType::Bishop:
+			return 'b';
+		case space::PieceType::Queen:
+			return 'q';
+		case space::PieceType::King:
+			return 'k';
+		case space::PieceType::None:
+			throw std::runtime_error("Cannot convert piece type 'None' to text");
+		default:
+			throw std::runtime_error("pieceType " + std::to_string(static_cast<int>(pieceType)) + " not recognized.");
+		}
+	}
+
+	char pieceToChar(space::Piece piece) {
+
+		char result = pieceTypeToChar(piece.pieceType);
+		if (piece.color == space::Color::White)
+			result = result + 'A' - 'a';
+		return result;
+	}
+
+	std::string board_as_plain_string(
+		const space::IBoard& board,
+		bool unicode_pieces,
+		space::Color perspective)
+	{
+		std::stringstream out;
+		out << "  |  a  b  c  d  e  f  g  h  |\n"
+			<< "--+--------------------------+--\n";
+		for (int rank = 7; rank >= 0; --rank)
+		{
+			out << (rank + 1) << " |  ";
+			for (int file = 0; file < 8; ++file)
+			{
+				auto piece = board.getPiece({ rank, file });
+				if (piece.has_value()) {
+					if (unicode_pieces) {
+						out << piece_to_unicode(piece.value()) << "  ";
+					}
+					else {
+						auto c = piece.value().pieceType != space::PieceType::None
+						    ? pieceToChar(piece.value())
+							: ' ';
+						out << c << "  ";
+					}
+				}
+				else {
+					out << ".  ";
+				}
+			}
+			out << "| " << (rank + 1) << "\n";
+			if (rank > 0)
+				out << "  |                          |  \n";
+		}
+		out << "--+--------------------------+--\n"
+			<< "  |  a  b  c  d  e  f  g  h  |\n\n";
+		return out.str();
+	}
+
+
 } // end anonymous namespace
 
 
@@ -137,7 +238,7 @@ namespace space {
 
 	}
 
-	bool BoardImpl::isCheckMate() const 
+	bool BoardImpl::isCheckMate() const
 	{
 		if (this->isUnderCheck(this->m_whoPlaysNext)) {
 			std::map<Move, IBoard::Ptr> allMoves = this->getValidMoves();
@@ -234,7 +335,7 @@ namespace space {
 			if (fileChange == 2 || fileChange == -2) {    // castling
 				int rookFile = (fileChange > 0 ? 7 : 0);
 				Piece pRook = this->m_pieces[move.sourceRank][rookFile];
-				space_assert(pRook.pieceType == PieceType::Rook && 
+				space_assert(pRook.pieceType == PieceType::Rook &&
 						pRook.color == pSource.color,
 					"Rook Not found for castling");
 
@@ -251,7 +352,7 @@ namespace space {
 			if (move.destinationRank == 0 || move.destinationRank == 7) {  // promotion
 				space_assert((move.destinationRank == 0) == (pSource.color == Color::Black),
 					"Pawn on back row");
-				pTargetNew.pieceType = move.promotedPiece; 
+				pTargetNew.pieceType = move.promotedPiece;
 			}
 
 			switch (pSource.color){
@@ -261,8 +362,8 @@ namespace space {
 						"White Pawn double move blocked");
 					pTargetNew.pieceType = PieceType::EnPassantCapturablePawn;
 				}
-				else if (move.sourceRank == 4 && 
-					newBoard->m_pieces[move.sourceRank][move.destinationFile].pieceType 
+				else if (move.sourceRank == 4 &&
+					newBoard->m_pieces[move.sourceRank][move.destinationFile].pieceType
 							== PieceType::EnPassantCapturablePawn){
 					newBoard->m_pieces[move.sourceRank][move.destinationFile].pieceType
 						= PieceType::None;    // En passant capture
@@ -320,7 +421,7 @@ namespace space {
 				abs(m.destinationFile - m.sourceFile) == 2   //Castling
 				) {
 				int castledir = (m.sourceFile - m.destinationFile) / 2;
-				if (this->isUnderCheck(color) ||            
+				if (this->isUnderCheck(color) ||
 					this->isUnderCheck(color, Position(m.sourceRank, m.sourceFile + castledir))
 					)
 					continue;
@@ -416,7 +517,7 @@ namespace space {
 			if (rank > 0)
 			{
 				ss.get(c);
-				if (c != '/') 
+				if (c != '/')
 					throw std::runtime_error(std::string("Expecting '/', got '") + c + "'");
 			}
 		}
@@ -479,7 +580,7 @@ namespace space {
 
 		return board;
 	}
-  
+
 	// In this we check for obstructions, returns true if no obstructions
 	bool BoardImpl::checkObstructions(Move m) const
 	{
@@ -509,7 +610,7 @@ namespace space {
 		int deltay = m.destinationFile - m.sourceFile;
 
 		// path obstruction calculation
-		if (pType == PieceType::Rook || pType == PieceType::Bishop || pType == PieceType::Queen) 
+		if (pType == PieceType::Rook || pType == PieceType::Bishop || pType == PieceType::Queen)
 		{
 			space_assert(deltax == 0 || deltay == 0 || abs(deltax) == abs(deltay),
 				"invalide long  move");
@@ -615,8 +716,8 @@ namespace space {
 		if (t == PieceType::King) {
 			for (int i = -1; i <= 1; i++) {
 				for (int j = -1; j <= 1; j++) {
-					if (((i != 0) || (j != 0)) && 
-						 inRange(i + rank) && inRange(j + file) ) 
+					if (((i != 0) || (j != 0)) &&
+						 inRange(i + rank) && inRange(j + file) )
 					{
 						moves.push_back({ rank, file, i + rank, j + file });
 					}
@@ -651,7 +752,7 @@ namespace space {
 		if (t == PieceType::Knight) {
 			for (int i = -1; i <= 1; i+= 2 ) {
 				for (int j = -1; j <= 1; j+= 2) {
-					for (int k = 1; k <= 2; k++) 
+					for (int k = 1; k <= 2; k++)
 					{
 						int tgtRank = rank + k * i;
 						int tgtFile = file + (3 - k) * j;
@@ -735,4 +836,42 @@ namespace space {
 		return moves;
 	}
 
+	std::string BoardImpl::as_string(
+			bool terminal_colors,
+			bool unicode_pieces,
+			Color perspective
+	) const {
+		if (!terminal_colors)
+			return board_as_plain_string(*this, unicode_pieces, perspective);
+		int start = perspective == Color::White ? 7 : 0;
+		int stop = perspective == Color::White ? -1 : 8;
+		int step = start > stop ? -1 : 1;
+
+		auto white_square = terminal_colors ? "\u001b[47m" : "";
+		auto black_square = terminal_colors ? "\u001b[45m" : "";
+		auto reset = "\u001b[0m";
+
+		std::stringstream ss;
+		for (int rank = start; rank != stop; rank += step) {
+			ss << " " << (rank + 1) << " ";
+			for (int file = 7 - start; file != 7 - stop; file -= step) {
+				auto square_color = (rank + file) % 2;
+				ss << (square_color == 1 ? white_square : black_square);
+
+				auto piece = m_pieces[rank][file];
+				if (unicode_pieces) {
+					ss << "\u001b[30m" << piece_to_unicode(piece);
+				}
+				else {
+					ss << (piece.pieceType != PieceType::None ? pieceToChar(piece) : ' ');
+				}
+				ss << ' ' << reset;
+			}
+			ss << std::endl;
+		}
+		ss << (perspective == Color::White ? "  a b c d e f g h" : "  h g f e d c b a")
+		   << std::endl;
+
+		return ss.str();
+	}
 }

--- a/chess/board_impl.h
+++ b/chess/board_impl.h
@@ -27,6 +27,11 @@ namespace space {
 
 		static Ptr getStartingBoard();
 		static Ptr fromFen(const Fen& fen);
+		std::string as_string(
+		        bool unicode_pieces = false, 
+		        bool terminal_colors = false, 
+		        Color perspective = Color::White
+		) const override;
 
 	private:
 		std::array<std::array<Piece, 8>, 8> m_pieces;


### PR DESCRIPTION
Added a pretty printer for a board that can use ansi terminal color escape sequences and unicode chess pieces. The appearance depends on the exact terminal and typeface used. Also, added options `--color` and `--unicode` to enable each of these. 

Sample appearance:
![image](https://user-images.githubusercontent.com/7114876/115157475-428ebf80-a03e-11eb-8830-89d73892aba9.png)
