### PR TITLE
Remove enpassant capturable pawn piece type

### DIFF
--- a/algo_linear/algoLinear.cpp
+++ b/algo_linear/algoLinear.cpp
@@ -17,7 +17,6 @@ namespace space {
 		space_assert(wtsVec.size() == 5,
 			"Need 5 weights for algo");
 		this->weights[PieceType::Pawn] = wtsVec[0];
-		this->weights[PieceType::EnPassantCapturablePawn] = wtsVec[0];
 		this->weights[PieceType::Rook] = wtsVec[1];
 		this->weights[PieceType::Knight] = wtsVec[2];
 		this->weights[PieceType::Bishop] = wtsVec[3];
@@ -78,7 +77,6 @@ namespace space {
 		space_assert(wtsVec.size() == 5, "Need 5 weights");
 		this->breadth = _breadth;
 		this->weights[PieceType::Pawn] = wtsVec[0];
-		this->weights[PieceType::EnPassantCapturablePawn] = wtsVec[0];
 		this->weights[PieceType::Rook] = wtsVec[1];
 		this->weights[PieceType::Knight] = wtsVec[2];
 		this->weights[PieceType::Bishop] = wtsVec[3];
@@ -97,8 +95,7 @@ namespace space {
 				}
 				Piece p = pMaybe.value();
 				int sign = p.color == Color::White ? 1 : -1;
-				if (p.pieceType == PieceType::Pawn || 
-					p.pieceType == PieceType::EnPassantCapturablePawn) {
+				if (p.pieceType == PieceType::Pawn) {
 					s += sign * (1 + this->weights[p.pieceType] * (sign == 1 ? (i - 1) : (6 - i)));
 				}
 				else {

--- a/algo_linear/algo_dumbo_impl.cpp
+++ b/algo_linear/algo_dumbo_impl.cpp
@@ -151,7 +151,6 @@ namespace algo_dumbo_impl {
 					switch (optPiece->pieceType)
 					{
 						case space::PieceType::Pawn:
-						case space::PieceType::EnPassantCapturablePawn:
 							totalScore += scoreFactor * config.pawnScore;
 							break;
 						case space::PieceType::Rook:

--- a/chess/board.h
+++ b/chess/board.h
@@ -6,7 +6,7 @@
 
 namespace space {
 	enum class Color { White, Black };
-	enum class PieceType { Pawn, EnPassantCapturablePawn, Rook, Knight, Bishop, Queen, King, None };
+	enum class PieceType { Pawn, Rook, Knight, Bishop, Queen, King, None };
 	struct Position {
 		int rank;
 		int file;
@@ -34,6 +34,8 @@ namespace space {
 		using MoveMap = std::map<Move, Ptr>;
 		virtual Color whoPlaysNext() const = 0;
 		virtual std::optional<Piece> getPiece(Position position) const = 0;
+
+		std::optional<Position> enPassantSquare;
 
 		// (Left and right from that player's point of view)
 		virtual bool canCastleLeft(Color color) const = 0;

--- a/chess/fen.cpp
+++ b/chess/fen.cpp
@@ -8,13 +8,10 @@ namespace {
 	char pieceToChar(space::Piece piece)
 	{
 		char result;
-		// Pawn, EnPessantCapturablePawn, Rook, Knight, Bishop, Queen, King, None
+		// Pawn, EnPassantCapturablePawn, Rook, Knight, Bishop, Queen, King, None
 		switch (piece.pieceType)
 		{
 		case space::PieceType::Pawn:
-			result = 'P';
-			break;
-		case space::PieceType::EnPassantCapturablePawn:
 			result = 'P';
 			break;
 		case space::PieceType::Rook:
@@ -49,7 +46,7 @@ namespace space {
 	Fen Fen::fromBoard(const IBoard::Ptr& board, int halfMoveClock, int fullMoves)
 	{
 		std::stringstream result;
-		std::optional<Position> enPessantPosition;
+		std::optional<Position> enPassantPosition = board->enPassantSquare;
 		for (int rank = 7; rank >= 0; --rank)
 		{
 			Position pos(rank, 1);
@@ -68,15 +65,6 @@ namespace space {
 					skip = 0;
 					auto piece = *optPiece;
 					result << pieceToChar(piece);
-
-					if (piece.pieceType == PieceType::EnPassantCapturablePawn)
-					{
-						enPessantPosition = pos;
-						if (piece.color == Color::Black)
-							++(enPessantPosition->rank);
-						else
-							--(enPessantPosition->rank);
-					}
 				}
 			}
 			if (skip > 0) result << skip;
@@ -95,12 +83,12 @@ namespace space {
 		if (!canCastle) result << '-';
 
 		result << ' ';
-		if (!enPessantPosition)
+		if (!enPassantPosition)
 			result << '-';
 		else
 		{
-			result << static_cast<char>('a' + enPessantPosition->file);
-			result << (enPessantPosition->rank + 1);
+			result << static_cast<char>('a' + enPassantPosition->file);
+			result << (enPassantPosition->rank + 1);
 		}
 
 		result << ' ' << halfMoveClock << ' ' << fullMoves;

--- a/chess_test/chess_test.cpp
+++ b/chess_test/chess_test.cpp
@@ -133,15 +133,15 @@ TEST(BoardSuite, FenEnpassantablePawnTest) {
 
 	auto fen = Fen("2rr2k1/p5pb/7p/1p5P/KPq3P1/8/8/8 w - b6 0 38");
 	auto board = BoardImpl::fromFen(fen);
-	auto piece_on_b5 = board->getPiece(Position(4, 1));
-	ASSERT_TRUE(piece_on_b5.has_value());
-	ASSERT_EQ(piece_on_b5.value().pieceType, PieceType::EnPassantCapturablePawn);
+	ASSERT_TRUE(board->enPassantSquare.has_value());
+	ASSERT_EQ(board->enPassantSquare.value().rank, 5);
+	ASSERT_EQ(board->enPassantSquare.value().file, 1);
 
 	fen = Fen("2rr2k1/p5pb/7p/1p5P/1Pp2qP1/K7/8/8 b - b3 0 1");
 	board = BoardImpl::fromFen(fen);
-	auto piece_on_b4 = board->getPiece(Position(3, 1));
-	ASSERT_TRUE(piece_on_b4.has_value());
-	ASSERT_EQ(piece_on_b4.value().pieceType, PieceType::EnPassantCapturablePawn);
+	ASSERT_TRUE(board->enPassantSquare.has_value());
+	ASSERT_EQ(board->enPassantSquare.value().rank, 2);
+	ASSERT_EQ(board->enPassantSquare.value().file, 1);
 }
 
 TEST(BoardSuite, EnpassantablePawnCheckTest) {
@@ -149,9 +149,9 @@ TEST(BoardSuite, EnpassantablePawnCheckTest) {
 
 	auto fen = Fen("2rr2k1/p5pb/7p/1p5P/KPq3P1/8/8/8 w - b6 0 38");
 	auto board = BoardImpl::fromFen(fen);
-	auto piece_on_b5 = board->getPiece(Position(4, 1));
-	ASSERT_TRUE(piece_on_b5.has_value());
-	ASSERT_EQ(piece_on_b5.value().pieceType, PieceType::EnPassantCapturablePawn);
+	ASSERT_TRUE(board->enPassantSquare.has_value());
+	ASSERT_EQ(board->enPassantSquare.value().rank, 5);
+	ASSERT_EQ(board->enPassantSquare.value().file, 1);
 
 	ASSERT_TRUE(board->isUnderCheck(Color::White));
 }
@@ -199,7 +199,7 @@ TEST(AlgoSuite, AlgoLinearTest) {
 	Fen boardfen = Fen("8/8/2kq1r2/8/2KBNR2/8/8/8 b - - 0 0");
 	auto b0 = BoardImpl::fromFen(boardfen);
 
-    //auto aa = AlgoLinearDepthOne(wts01);
+	//auto aa = AlgoLinearDepthOne(wts01);
 	auto aa = AlgoLinearDepthTwoExt(5, wts01);
 
 	Move m0 = aa.getNextMove(b0);

--- a/chess_test/test_positions.h
+++ b/chess_test/test_positions.h
@@ -4,6 +4,7 @@
 
 #include <memory>
 #include <vector>
+#include <string>
 
 namespace space {
 

--- a/game/CliAlgo.cpp
+++ b/game/CliAlgo.cpp
@@ -89,8 +89,6 @@ namespace {
 		{
 		case space::PieceType::Pawn:
 			return 'p';
-		case space::PieceType::EnPassantCapturablePawn:
-			return 'p';
 		case space::PieceType::Rook:
 			return 'r';
 		case space::PieceType::Knight:


### PR DESCRIPTION
This PR removes the `PieceType::EnPassantCapturablePawn` and instead stores the en passant square in the board itself. This avoids issues with having to match or check for both pawns or en passant capturable pawns everywhere.